### PR TITLE
[10.0] mass: improve handling of analytic

### DIFF
--- a/donation_mass/donation_mass_demo.xml
+++ b/donation_mass/donation_mass_demo.xml
@@ -34,7 +34,6 @@
 </record>
 
 <record id="donation_mass1" model="donation.donation">
-    <field name="currency_id" ref="base.EUR"/>
     <field name="check_total">17</field>
     <field name="partner_id" ref="donor_mass1"/>
     <field name="donation_date" eval="time.strftime('%Y-%m-01')"/>
@@ -51,7 +50,6 @@
 </record>
 
 <record id="donation_mass2" model="donation.donation">
-    <field name="currency_id" ref="base.EUR"/>
     <field name="check_total">340</field>
     <field name="partner_id" ref="donor_mass2"/>
     <field name="donation_date" eval="time.strftime('%Y-%m-01')"/>
@@ -68,7 +66,6 @@
 </record>
 
 <record id="donation_mass3" model="donation.donation">
-    <field name="currency_id" ref="base.EUR"/>
     <field name="check_total">540</field>
     <field name="partner_id" ref="donor_mass3"/>
     <field name="donation_date" eval="time.strftime('%Y-%m-01')"/>

--- a/donation_stay/tests/test_donate_from_stay.py
+++ b/donation_stay/tests/test_donate_from_stay.py
@@ -14,10 +14,13 @@ class TestDonationFromStay(TransactionCase):
             'active_id': self.env.ref('stay.stay2').id,
             'active_ids': [self.env.ref('stay.stay2').id],
             'active_model': 'stay.stay'}
+        bq_journal = self.env['account.journal'].search(
+            [('type', '=', 'bank')])
+        payment_ref = 'CHQ LBP 421242'
         wiz = dsco.with_context(ctx).create({
-            'journal_id': self.env.ref('account.check_journal').id,
+            'journal_id': bq_journal[0].id,
             'amount': 200,
-            'payment_ref': 'CHQ LBP 421242'})
+            'payment_ref': payment_ref})
         action = wiz.create_donation()
         donation_id = action['res_id']
         donation = self.env['donation.donation'].browse(donation_id)
@@ -29,5 +32,5 @@ class TestDonationFromStay(TransactionCase):
             donation.partner_id, self.env.ref('base.res_partner_address_2'))
         self.assertEquals(donation.move_id.state, 'posted')
         self.assertEquals(
-            donation.move_id.journal_id, self.env.ref('account.check_journal'))
-        self.assertEquals(donation.move_id.ref, 'CHQ LBP 421242')
+            donation.move_id.journal_id, bq_journal[0])
+        self.assertEquals(donation.move_id.ref, payment_ref)

--- a/donation_stay/tests/test_donate_from_stay.py
+++ b/donation_stay/tests/test_donate_from_stay.py
@@ -4,18 +4,16 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import TransactionCase
-from odoo import fields
 
 
 class TestDonationFromStay(TransactionCase):
 
     def test_donate_from_stay(self):
         dsco = self.env['donation.stay.create']
-        ctx = self._context.copy()
-        ctx.update({
+        ctx = {
             'active_id': self.env.ref('stay.stay2').id,
             'active_ids': [self.env.ref('stay.stay2').id],
-            'active_model': 'stay.stay'})
+            'active_model': 'stay.stay'}
         wiz = dsco.with_context(ctx).create({
             'journal_id': self.env.ref('account.check_journal').id,
             'amount': 200,

--- a/donation_stay/tests/test_donate_from_stay.py
+++ b/donation_stay/tests/test_donate_from_stay.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# Copyright 2017-2019 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import TransactionCase
@@ -9,7 +10,6 @@ from odoo import fields
 class TestDonationFromStay(TransactionCase):
 
     def test_donate_from_stay(self):
-        today = fields.Date.context_today(self)
         dsco = self.env['donation.stay.create']
         ctx = self._context.copy()
         ctx.update({
@@ -30,7 +30,6 @@ class TestDonationFromStay(TransactionCase):
         self.assertEquals(
             donation.partner_id, self.env.ref('base.res_partner_address_2'))
         self.assertEquals(donation.move_id.state, 'posted')
-        self.assertEquals(donation.move_id.date, today)
         self.assertEquals(
             donation.move_id.journal_id, self.env.ref('account.check_journal'))
         self.assertEquals(donation.move_id.ref, 'CHQ LBP 421242')

--- a/donation_stay/tests/test_donate_from_stay.py
+++ b/donation_stay/tests/test_donate_from_stay.py
@@ -25,7 +25,8 @@ class TestDonationFromStay(TransactionCase):
         donation_id = action['res_id']
         donation = self.env['donation.donation'].browse(donation_id)
         self.assertEquals(donation.state, 'draft')
-        self.assertEquals(donation.campaign_id, self.env.ref('stay_campaign'))
+        self.assertEquals(
+            donation.campaign_id, self.env.ref('donation_stay.stay_campaign'))
         self.assertEquals(donation.amount_total, 200)
         donation.validate()
         self.assertEquals(

--- a/mass/__manifest__.py
+++ b/mass/__manifest__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# © 2014-2017 Barroux Abbey (www.barroux.org)
-# © 2014-2017 Akretion France (www.akretion.com)
+# Copyright 2014-2019 Barroux Abbey (www.barroux.org)
+# Copyright 2014-2019 Akretion France (www.akretion.com)
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 
 {
     'name': 'Mass',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Christian Religion',
     'license': 'AGPL-3',
     'summary': 'Manage Mass',

--- a/mass/base_config_settings.py
+++ b/mass/base_config_settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2017 Barroux Abbey (www.barroux.org)
-# © 2017 Akretion France (www.akretion.com)
+# Copyright 2017-2019 Barroux Abbey (www.barroux.org)
+# Copyright 2017-2019 Akretion France (www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -11,8 +11,9 @@ class BaseConfigSettings(models.TransientModel):
     _inherit = 'base.config.settings'
 
     mass_validation_account_id = fields.Many2one(
-        related='company_id.mass_validation_account_id',
-        domain=[('deprecated', '!=', True)])
+        related='company_id.mass_validation_account_id')
+    mass_validation_analytic_account_id = fields.Many2one(
+        related='company_id.mass_validation_analytic_account_id')
     mass_validation_journal_id = fields.Many2one(
         related='company_id.mass_validation_journal_id')
     mass_post_move = fields.Boolean(related='company_id.mass_post_move')

--- a/mass/base_config_settings_view.xml
+++ b/mass/base_config_settings_view.xml
@@ -15,6 +15,8 @@
         <group name="google_analytics" position="after">
             <group name="mass" string="Mass">
                 <field name="mass_validation_account_id"/>
+                <field name="mass_validation_analytic_account_id"
+                    groups="analytic.group_analytic_accounting"/>
                 <field name="mass_validation_journal_id"/>
                 <field name="mass_post_move"/>
             </group>

--- a/mass/company.py
+++ b/mass/company.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2014-2017 Barroux Abbey (www.barroux.org)
-# © 2014-2017 Akretion France (www.akretion.com)
+# Copyright 2014-2019 Barroux Abbey (www.barroux.org)
+# Copyright 2014-2019 Akretion France (www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # @author: Brother Bernard <informatique@barroux.org>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -14,6 +14,9 @@ class ResCompany(models.Model):
     mass_validation_account_id = fields.Many2one(
         'account.account', string='Mass Validation Account',
         domain=[('deprecated', '!=', True)])
+    mass_validation_analytic_account_id = fields.Many2one(
+        'account.analytic.account',
+        string='Mass Validation Analytic Account')
     mass_validation_journal_id = fields.Many2one(
         'account.journal', string='Mass Validation Journal')
     mass_post_move = fields.Boolean(string='Post Move', default=True)

--- a/mass/mass.py
+++ b/mass/mass.py
@@ -144,8 +144,7 @@ class MassRequest(models.Model):
         'account.account', string='Stock Account',
         domain=[('deprecated', '!=', True)])
     analytic_account_id = fields.Many2one(
-        'account.analytic.account', string='Analytic Account',
-        domain=[('type', 'not in', ('view', 'template'))])
+        'account.analytic.account', string='Stock Analytic Account')
     company_id = fields.Many2one(
         'res.company', string='Company', required=True, ondelete='restrict',
         default=lambda self: self.env['res.company']._company_default_get(

--- a/mass/wizard/generate_mass_journal.py
+++ b/mass/wizard/generate_mass_journal.py
@@ -156,11 +156,11 @@ class MassJournalGenerate(models.TransientModel):
                 if celebrant_id in celebrant_ids:
                     celebrant_ids.remove(celebrant_id)
                 elif celebrant_id not in origin_celebrant_ids:
-                        raise UserError(_(
-                            'The celebrant %s has an assigned mass for %s, '
-                            'but he is not available today.') % (
-                                line['request'].celebrant_id.name,
-                                line['request'].partner_id.name))
+                    raise UserError(_(
+                        'The celebrant %s has an assigned mass for %s, '
+                        'but he is not available today.') % (
+                            line['request'].celebrant_id.name,
+                            line['request'].partner_id.name))
                 else:
                     raise UserError(_(
                         'More than one mass are assigned '


### PR DESCRIPTION
On mass.request, we store the analytic account for stock
New field on res.company that store the analytic account for income used upon mass validation

That way, the behavior is coherent between legal account and analytic account !